### PR TITLE
Create event loop, if code is executing in non-main thread.

### DIFF
--- a/django_walletpass/services.py
+++ b/django_walletpass/services.py
@@ -12,7 +12,11 @@ logger = logging.getLogger('walletpass.services')
 
 class PushBackend:
     def __init__(self):
-        self.loop = asyncio.get_event_loop()
+        try:
+            self.loop = asyncio.get_event_loop()
+        except RuntimeError:
+            self.loop = asyncio.new_event_loop()
+            asyncio.set_event_loop(self.loop)
 
     async def push_notification(self, client, token):
 


### PR DESCRIPTION
if code is executing in a non-main thread: By default, the main thread in Python has an event loop set up automatically. However, if the code is running in a separate thread, we need to manually create and set up an event loop for that thread.